### PR TITLE
Use jade-compatible quotes

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -4,7 +4,7 @@ html(lang='en')
     meta(charset='utf-8')
     title = locals.article ? article.title + ' — ' : ''
     title #{title}n8.io
-    meta(name='description', content='TooTallNate\'s Blog')
+    meta(name='description', content="TooTallNate's Blog")
     meta(name='keywords', content='TooTallNate n8 node.js')
     meta(name='author', content='Nathan Rajlich')
     meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')


### PR DESCRIPTION
Jade doesn't support escaping quotes in attributes for some reason, so the content attribute is just dropped from the output, producing invalid HTML!
